### PR TITLE
Specifying -std=c90 for ctypes

### DIFF
--- a/lib/python/ctypes/Makefile
+++ b/lib/python/ctypes/Makefile
@@ -63,7 +63,7 @@ endif
 
 SED = sed
 CTYPESGEN = ./ctypesgen.py
-CTYPESFLAGS = --cpp "$(CC) -E $(CPPFLAGS) $(LFS_CFLAGS) $(MAC_FLAGS) $(EXTRA_CFLAGS) $(NLS_CFLAGS) $(DEFS) $(EXTRA_INC) $(INC) -D__GLIBC_HAVE_LONG_LONG"
+CTYPESFLAGS = --cpp "$(CC) -E $(CPPFLAGS) $(LFS_CFLAGS) $(MAC_FLAGS) $(EXTRA_CFLAGS) -std=c90 $(NLS_CFLAGS) $(DEFS) $(EXTRA_INC) $(INC) -D__GLIBC_HAVE_LONG_LONG"
 EXTRA_CLEAN_FILES := $(wildcard ctypesgencore/*.pyc) $(wildcard ctypesgencore/*/*.pyc)
 
 ifneq ($(MINGW),)


### PR DESCRIPTION
Fixing https://github.com/OSGeo/grass/pull/507